### PR TITLE
Switch occurrences of setRootAge and setRootAges

### DIFF
--- a/R/obtainDatedPosteriorTreesMrB.R
+++ b/R/obtainDatedPosteriorTreesMrB.R
@@ -348,11 +348,11 @@ obtainDatedPosteriorTreesMrB <- function(
 			attr(outTree,"fixedTable") <- fixedTable
 			#message("For use in R with paleotree and other packages, you may want to set the root age")
 			if(!is(outTree,"multiPhylo")){
-				#message("Simply use function setRootAges() next")
-				outTree<-setRootAges(outTree)
-			}else{
 				#message("Simply use function setRootAge() next")
 				outTree<-setRootAge(outTree)
+			}else{
+				#message("Simply use function setRootAges() next")
+				outTree<-setRootAges(outTree)
 				}
 			}
 		return(outTree)


### PR DESCRIPTION
I got an error on the number of trees running `setRootAges` when trying to use this script; I think that the occurrences of `setRootAges` and `setRootAge` in lines 352 and 355 should be switched:

Line 350: `if(!is(outTree, "multiPhylo"))` implies is _not_ `multiPhylo` object, therefore use `setRootAge` in line 352, whereas
Line 353: `else` refers to `multiPhylo` objects (_not_ `phylo`), therefore use setRootAges in line 355.